### PR TITLE
[DO NOT MERGE] Add two commands, Head and MdsHead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,12 @@ fibers = "0.1"
 fibers_global = "0.1"
 fibers_rpc = "0.2"
 futures = "0.1"
-libfrugalos = "0.2.1"
+libfrugalos = { git = "https://github.com/yuezato/libfrugalos", branch = "alternative_head" }
 slog = "2"
 sloggers = "0.3"
 serde = "1"
 serde_derive = "1"
 trackable = "0.2"
+
+[patch.crates-io]
+libfrugalos = { git = "https://github.com/yuezato/libfrugalos", branch = "alternative_head" }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -20,9 +20,13 @@ use Result;
 
 pub mod object;
 
-#[allow(missing_docs)]
+/// Context for a one shot command that uses RPC.
+/// It consists of a logger and a frugalos rpc client.
 pub struct OneshotCommandContext {
+    /// logger to be logged by a oneshot command.
     pub logger: Logger,
+
+    /// frugalos rpc client.
     pub frugalos_client: Client,
 }
 
@@ -99,6 +103,30 @@ pub enum SubCommandOptions {
         /// insufficient because an `ObjectId` may contain an arbitrary character.
         #[structopt(long = "object-ids", default_value = "")]
         object_ids: String,
+    },
+
+    #[structopt(name = "head")]
+    Head {
+        #[structopt(long = "rpc-addr", default_value = "127.0.0.1:14278")]
+        rpc_addr: SocketAddr,
+
+        #[structopt(long = "bucket")]
+        bucket: BucketId,
+
+        #[structopt(long = "object-id")]
+        object_id: String,
+    },
+
+    #[structopt(name = "mds-head")]
+    MdsHead {
+        #[structopt(long = "rpc-addr", default_value = "127.0.0.1:14278")]
+        rpc_addr: SocketAddr,
+
+        #[structopt(long = "bucket")]
+        bucket: BucketId,
+
+        #[structopt(long = "object-id")]
+        object_id: String,
     },
 }
 

--- a/src/command/object.rs
+++ b/src/command/object.rs
@@ -4,7 +4,7 @@ use fibers_global;
 use futures::Future;
 use libfrugalos::entity::bucket::BucketId;
 use libfrugalos::entity::device::DeviceId;
-use libfrugalos::entity::object::ObjectId;
+use libfrugalos::entity::object::{ObjectId, ObjectVersion};
 
 use std::collections::BTreeSet;
 
@@ -35,6 +35,74 @@ impl DeleteObjectsByIds {
             self.context
                 .frugalos_client
                 .delete_from_device_by_object_ids(bucket_id, device_id, object_ids)
+                .map_err(|e| track!(e)),
+        );
+        fibers_global::execute(fiber).map_err(|e| track!(Error::from(e)))
+    }
+}
+
+/// This command issues Head rpc with a given bucket_id and object_id.
+pub struct Head {
+    context: OneshotCommandContext,
+}
+
+impl Head {
+    /// Creates a new instance of `MdsHead`.
+    pub fn new(context: OneshotCommandContext) -> Self {
+        Head { context }
+    }
+
+    /// Issues Head with the given `object_id` of the given `bucket_id`.
+    pub fn run(
+        &mut self,
+        bucket_id: BucketId,
+        object_id: ObjectId,
+    ) -> Result<Option<ObjectVersion>> {
+        use std::time::Duration;
+
+        let fiber = fibers_global::handle().spawn_monitor(
+            self.context
+                .frugalos_client
+                .head_object(
+                    bucket_id,
+                    object_id,
+                    Duration::from_secs(30),
+                    Default::default(),
+                )
+                .map_err(|e| track!(e)),
+        );
+        fibers_global::execute(fiber).map_err(|e| track!(Error::from(e)))
+    }
+}
+
+/// This command issues MdsHead rpc with a given bucket_id and object_id.
+pub struct MdsHead {
+    context: OneshotCommandContext,
+}
+
+impl MdsHead {
+    /// Creates a new instance of `MdsHead`.
+    pub fn new(context: OneshotCommandContext) -> Self {
+        MdsHead { context }
+    }
+
+    /// Issues MdsHead with the given `object_id` of the given `bucket_id`.
+    pub fn run(
+        &mut self,
+        bucket_id: BucketId,
+        object_id: ObjectId,
+    ) -> Result<Option<ObjectVersion>> {
+        use std::time::Duration;
+
+        let fiber = fibers_global::handle().spawn_monitor(
+            self.context
+                .frugalos_client
+                .mds_head_object(
+                    bucket_id,
+                    object_id,
+                    Duration::from_secs(30),
+                    Default::default(),
+                )
                 .map_err(|e| track!(e)),
         );
         fibers_global::execute(fiber).map_err(|e| track!(Error::from(e)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ extern crate serde;
 extern crate serde_derive;
 extern crate slog;
 extern crate sloggers;
-#[macro_use]
 extern crate structopt;
 #[macro_use]
 extern crate trackable;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,12 @@ extern crate structopt;
 extern crate trackable;
 
 use frugalostool::command;
-use frugalostool::command::object::DeleteObjectsByIds;
+use frugalostool::command::object::*;
 use frugalostool::Result;
 use sloggers::Build;
 use structopt::StructOpt;
 
-#[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
+#[allow(clippy::cyclomatic_complexity)]
 fn main() -> Result<()> {
     let options = command::ApplicationOptions::from_args();
     let logger_builder = if let Some(filepath) = options.global.log_file {
@@ -40,6 +40,28 @@ fn main() -> Result<()> {
             let object_ids = command::parse_object_ids(&object_ids, &delimiter);
             let context = command::OneshotCommandContext::new(logger.clone(), rpc_addr)?;
             track!(DeleteObjectsByIds::new(context).run(bucket, device, object_ids))?;
+        }
+        command::SubCommandOptions::Head {
+            rpc_addr,
+            bucket,
+            object_id,
+        } => {
+            let context = command::OneshotCommandContext::new(logger.clone(), rpc_addr)?;
+
+            let result = track!(Head::new(context).run(bucket, object_id))?;
+
+            println!("result = {:?}", result);
+        }
+        command::SubCommandOptions::MdsHead {
+            rpc_addr,
+            bucket,
+            object_id,
+        } => {
+            let context = command::OneshotCommandContext::new(logger.clone(), rpc_addr)?;
+
+            let result = track!(MdsHead::new(context).run(bucket, object_id))?;
+
+            println!("result = {:?}", result);
         }
     }
 


### PR DESCRIPTION
# MdsHead
```
$ ./target/debug/frugalostool mds-head --bucket bucket0 --object-id your_object_id
# This only uses the <lumpid, lumpversion> table in a raft cluster
```

# Head
```
$ ./target/debug/frugalostool head --bucket bucket0 --object-id your_object_id
# This uses the <lumpid, lumpversion> table in a raft cluster
# and then issue a cannyls-rpc head command to confirm if the `object-id` is really available
```