### PR TITLE
Supports `create-docker-compose` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ Run:
 ```console
 $ frugalostool -h
 ```
+
+### Creates a `docker-compose.yml`
+
+`create-docker-compose` command generates a `docker-compose.yml` and outputs a result to stdout.
+Keep in mind that a generated `docker-compose.yml` is used for running a cluster NOT in a production environment but a development environment.
+
+An example:
+
+```console
+$ frugalostool create-docker-compose --cluster-size 10 > /tmp/docker-compose.yml
+```
+
+Currently, `--cluster-addr-start` and `--node-index-start` don't work properly due to the limitation of `bootstrap.sh` and `join.sh` in `frugalos/frugalos` repository.

--- a/src/command/cluster.rs
+++ b/src/command/cluster.rs
@@ -1,0 +1,98 @@
+//! This module provides some ways to control a frugalos cluster.
+use std::io::{self, Write};
+
+use error::Error;
+use Result;
+
+/// A command for creating `docker-compose.yml`.
+/// There is no standard method for generating `docker-compose.yml` programatically,
+/// so this struct gives some help.
+pub struct CreateDockerCompose;
+
+impl CreateDockerCompose {
+    /// Creates a new `CreateDockerCompose`.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Runs this command.
+    pub fn run(
+        &self,
+        cluster_size: u8,
+        cluster_addr_start: u8,
+        node_index_start: u8,
+    ) -> Result<()> {
+        DockerComposeFile::new(cluster_addr_start)
+            .add_nodes(cluster_size, node_index_start)
+            .write_to(&mut io::stdout())
+    }
+}
+
+/// A content of `docker-compose.yml`.
+struct DockerComposeFile {
+    buffer: String,
+    addr_start: u8,
+}
+
+impl DockerComposeFile {
+    fn new(addr_start: u8) -> Self {
+        let mut buffer = String::new();
+        buffer.push_str("version: '2'\n");
+        buffer.push_str(&format!(
+            "
+networks:
+  frugalos_net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.18.0.0/16
+"
+        ));
+        buffer.push_str("\n");
+        buffer.push_str("services:");
+        Self { buffer, addr_start }
+    }
+
+    /// Adds frugalos nodes to a content.
+    fn add_nodes(mut self, cluster_size: u8, node_index_start: u8) -> Self {
+        for i in node_index_start..(node_index_start + cluster_size) {
+            let data_dir = format!("/tmp/frugalos_it/frugalos{}/", i);
+            let hostname = format!("frugalos{}", i);
+            let command = if i == node_index_start {
+                format!("bootstrap.sh")
+            } else {
+                format!("join.sh")
+            };
+            let addr = format!("172.18.0.{}", self.addr_start);
+            let depends_on = if i == node_index_start {
+                format!("")
+            } else {
+                format!("depends_on: \n      - frugalos{}", node_index_start)
+            };
+            self.addr_start += 1;
+            self.buffer.push_str(&format!(
+                "
+  {}:
+    image: frugalos
+    hostname: {}
+    command: {}
+    volumes:
+      - {}:/var/lib/frugalos/
+    networks:
+      frugalos_net:
+        ipv4_address: {}
+    env_file: frugalos.env
+    {}
+",
+                hostname, hostname, command, data_dir, addr, depends_on
+            ));
+        }
+        self
+    }
+
+    fn write_to<W: Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(self.buffer.as_bytes())
+            .map(|_| ())
+            .map_err(|e| track!(Error::from(e)))
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 use error::Error;
 use Result;
 
+pub mod cluster;
 pub mod object;
 
 #[allow(missing_docs)]
@@ -79,6 +80,20 @@ pub struct GlobalOptions {
 #[derive(Debug, StructOpt)]
 #[allow(missing_docs)]
 pub enum SubCommandOptions {
+    #[structopt(name = "create-docker-compose")]
+    CreateDockerCompose {
+        /// specifies how many nodes you need
+        #[structopt(long = "cluster-size", default_value = "3")]
+        cluster_size: u8,
+
+        /// specifies the start index of network address used in a cluster
+        #[structopt(long = "cluster-addr-start", default_value = "21")]
+        cluster_addr_start: u8,
+
+        /// specifies the start index of nodes.
+        #[structopt(long = "node-index-start", default_value = "0")]
+        node_index_start: u8,
+    },
     #[structopt(name = "delete-objects-by-ids")]
     DeleteObjectsByIds {
         #[structopt(long = "rpc-addr", default_value = "127.0.0.1:14278")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate structopt;
 extern crate trackable;
 
 use frugalostool::command;
+use frugalostool::command::cluster::CreateDockerCompose;
 use frugalostool::command::object::DeleteObjectsByIds;
 use frugalostool::Result;
 use sloggers::Build;
@@ -29,6 +30,17 @@ fn main() -> Result<()> {
 
     // SubCommands
     match options.command {
+        command::SubCommandOptions::CreateDockerCompose {
+            cluster_size,
+            cluster_addr_start,
+            node_index_start,
+        } => {
+            track!(CreateDockerCompose::new().run(
+                cluster_size,
+                cluster_addr_start,
+                node_index_start
+            ))?;
+        }
         command::SubCommandOptions::DeleteObjectsByIds {
             rpc_addr,
             bucket,


### PR DESCRIPTION
docker-compose を自動生成するためのコマンドの追加。

汎用的に利用できるものではなく、

https://github.com/frugalos/frugalos/blob/master/it/clusters/ten-nodes.yml

と同様の前提でしか動作しません。